### PR TITLE
Use recent openjdk:26-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre-slim AS builder
+FROM openjdk:26-slim AS builder
 
 ARG CEREBRO_VERSION=0.9.4
 


### PR DESCRIPTION
- openjdk:26-slim have snyk identified vulnerabilities fixed thus using that